### PR TITLE
Added Fan Speed / Suction Level Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,37 @@ If it all worked out, you should now have Wyze vacuum entity(ies)
 - Return to Base
 - Room Clean (Must use serivce call) Example: ![image](https://user-images.githubusercontent.com/18567128/127786476-ec3dbfcd-66f4-40e6-bfe5-fda0edad191d.png)
 
+```yaml
+service: vacuum.send_command
+data:
+  command: sweep_rooms
+  params:
+    rooms:
+      - Hallway
+      - Kitchen
+target:
+  entity_id: vacuum.theovac
+```
+
+- Fan Speed control - `quiet` `standard` `strong` Example: ![image](https://user-images.githubusercontent.com/18567128/128625430-29f77538-b638-481e-8221-0e10ff8618a9.png)
+
+```yaml
+service: vacuum.set_fan_speed
+data:
+  fan_speed: quiet
+target:
+  entity_id: vacuum.your_vac
+```
+
+
 ## Misc
 - Location is not supported but it is considered "supported" by HA so the button doesn't crash the component when using vacuum-card if you use it.
 
+
 ## TODO / Maybe in the Future
 - In theory everything from wyze-sdk should be possible?
+- Update wyze_sdk to no longer require the suggested tweak above
+- Add battery level once wyze_sdk battery query works again
 
 
 ## Shoutouts

--- a/custom_components/simple_wyze_vac/__init__.py
+++ b/custom_components/simple_wyze_vac/__init__.py
@@ -1,6 +1,8 @@
 import logging
 import voluptuous as vol
 
+from datetime import timedelta
+
 from homeassistant import core
 from homeassistant.helpers import discovery
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -31,6 +33,8 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+SCAN_INTERVAL = timedelta(minutes=2)
+
 # async def async_setup(hass: core.HomeAssistant, config: dict) -> bool:
 def setup(hass: core.HomeAssistant, config: dict) -> bool:
     """Set up the Simple Wyze Vacuum component."""
@@ -53,7 +57,8 @@ def setup(hass: core.HomeAssistant, config: dict) -> bool:
         payload = {
             "mac": device.mac,
             "model": device.product.model,
-            "name": device.nickname
+            "name": device.nickname,
+            # "suction": device.clean_level #TODO - wyze_sdk currently broken self._clean_level != self.clean_level. Needs to be fixed first. 
         }
 
         hass.data[WYZE_VACUUMS].append(payload)


### PR DESCRIPTION
- Added Fan Speed / Suction Level Support 
Sample service call, or use the built in list 
```yaml
service: vacuum.set_fan_speed
data:
  fan_speed: quiet
target:
  entity_id: vacuum.your_vac
```
Available speeds: `quiet` `standard` `strong`

- Lowered polling from 20 sec to 2 min (This seems long but for the most part, at least for me, the vacuum is idle most of the time)

- Fixed "error" state when really paused