### PR TITLE
Additional Attributes

### DIFF
--- a/custom_components/simple_wyze_vac/vacuum.py
+++ b/custom_components/simple_wyze_vac/vacuum.py
@@ -100,6 +100,10 @@ class WyzeVac(StateVacuumEntity):
         self._filter = pl["filter"]
         self._main_brush = pl["main_brush"]
         self._side_brush = pl["side_brush"]
+        
+        self._last_clean_size = None
+        self._last_clean_duration = None
+        self._last_cleaned = None
 
         self._username = username
         self._password = password
@@ -193,6 +197,12 @@ class WyzeVac(StateVacuumEntity):
             data["side_brush"] = int(self._side_brush)
         if self._rooms is not None:
             data["rooms"] = self._rooms
+        if self._last_clean_size is not None:
+            data["last_clean_size"] = self._last_clean_size
+        if self._last_clean_duration is not None:
+            data["last_clean_duration"] = self._last_clean_duration
+        if self._last_cleaned is not None:
+            data["last_cleaned"] = self._last_cleaned
 
         return data
 
@@ -371,7 +381,21 @@ class WyzeVac(StateVacuumEntity):
             finally:
                 await self.hass.async_add_executor_job(lambda: self._client.vacuums.set_suction_level(device_mac=self._vac_mac, device_model=self._model, suction_level=wyze_suction))
             self.async_schedule_update_ha_state(force_refresh=True)
-    
+            
+    def time_ago(self, dt):
+        diff = datetime.now() - dt
+        seconds = int(diff.total_seconds())
+        if seconds < 60:
+            return f"{seconds}s"
+        elif seconds < 3600:
+            return f"{seconds // 60}m"
+        elif seconds < 86400:
+            return f"{seconds // 3600}h"
+        elif seconds < 31536000:
+            return f"{seconds // 86400}d"
+        else:
+            return f"{seconds // 31536000}y"
+        
     async def get_last_map(self):
         try:
             vacuum = await self.hass.async_add_executor_job(lambda: self._client.vacuums.info(device_mac=self._vac_mac))
@@ -384,6 +408,11 @@ class WyzeVac(StateVacuumEntity):
         latest = None
         try:
             latest = await self.hass.async_add_executor_job(lambda: self._client.vacuums.get_sweep_records(device_mac=self._vac_mac, since=datetime.now())[0])
+            if latest:
+                self._last_clean_size = round(latest.clean_size / 100 * 10.7639, 1)  # convert m^2 (×100) to sqft, see sdk docs
+                self._last_clean_duration = latest.clean_time
+                self._last_cleaned = self.time_ago(latest.started)
+
         except:
             _LOGGER.warn("Could not grab latest map, will use maps from maps list")
         url = None


### PR DESCRIPTION
I added additional attributes for the most recent clean. My use case for this is to create a "side B" card that contains all information about the most recent clean. This is useful because the map image always represents the most recent clean, rather than the current state. Instead of having a toggle just for the map (as in the examples), these attributes allow us to toggle between the vacuum's current state and its most recent clean state as full cards.

Added attributes:
- Area of most recent clean in sqft
- Duration of most recent clean
- Time since last clean (e.g., 50m ago)

**Example Usage:**

1. Side A, showing current state:
<img width="446" height="543" alt="Screenshot 2026-06-01 at 22 41 19" src="https://github.com/user-attachments/assets/b9164a7b-89b7-41a3-9496-7f03837f0876" />

P.S., Any idea why the supplies values are negative? I haven't been able to solve this. All of the supplies are newly replaced.

2. Side B, triggered by the map shortcut, showing information about the last clean:
<img width="446" height="519" alt="Screenshot 2026-06-01 at 22 41 29" src="https://github.com/user-attachments/assets/c2afeb1b-9eee-4037-8a0f-ed88b7500d12" />

<details>
<summary>Card Yaml</summary>

```yaml
type: vertical-stack
cards:
  - type: conditional
    conditions:
      - entity: input_boolean.vacuum_map
        state: "off"
    card:
      type: custom:vacuum-card
      entity: vacuum.vacuum
      image: default
      show_toolbar: true
      show_status: true
      show_name: true
      battery_entity: sensor.vacuum_battery
      compact_view: false
      stats:
        default:
          - attribute: filter
            unit: hours
            subtitle: Filter
          - attribute: side_brush
            unit: hours
            subtitle: Side brush
          - attribute: main_brush
            unit: hours
            subtitle: Main brush
      shortcuts:
        - name: Toggle map
          service: input_boolean.toggle
          service_data:
            entity_id: input_boolean.vacuum_map
          icon: mdi:map
        - name: Update
          service: script.vacuum_update_state
          icon: mdi:update
  - type: conditional
    conditions:
      - entity: input_boolean.vacuum_map
        state: "on"
    card:
      type: custom:vacuum-card
      entity: vacuum.vacuum
      map: camera.vacuum_camera
      show_toolbar: true
      show_status: false
      show_name: false
      battery_entity: sensor.vacuum_battery
      compact_view: false
      stats:
        default:
          - attribute: last_cleaned
            unit: ago
            subtitle: Last Clean
          - attribute: last_clean_duration
            unit: min
            subtitle: Duration
          - attribute: last_clean_size
            unit: sqft
            subtitle: Area
      shortcuts:
        - name: Toggle map
          service: input_boolean.toggle
          service_data:
            entity_id: input_boolean.vacuum_map
          icon: mdi:map
        - name: Update
          service: script.vacuum_update_state
          icon: mdi:update
grid_options:
  columns: 9
  rows: auto
```
</details>